### PR TITLE
Reduce per-thread weight storage in upd

### DIFF
--- a/src/libxsmm_dnn_handle.c
+++ b/src/libxsmm_dnn_handle.c
@@ -1598,7 +1598,7 @@ LIBXSMM_API_DEFINITION libxsmm_dnn_err_t libxsmm_dnn_internal_create_conv_handle
           handle->scratch4 = 0;
           handle->scratch4_size = handle->desc.threads * handle->blocksifm * handle->ifmblock * handle->blocksofm * handle->ofmblock
             * handle->desc.R * handle->desc.S * handle->fm_lp_block * libxsmm_dnn_typesize(handle->datatype);
-          handle->scratch4_size += handle->desc.threads * handle->block_upd_ofm * handle->block_upd_ifm * handle->desc.R
+          handle->scratch4_size += handle->desc.threads * LIBXSMM_MIN(handle->block_upd_ofm, handle->blocksofm) * LIBXSMM_MIN(handle->block_upd_ifm, handle->blocksifm) * handle->desc.R
             * handle->desc.S * handle->ifmblock * handle->ofmblock * libxsmm_dnn_typesize(handle->datatype);
 
           /* enable external reduce of filter scratch */

--- a/src/template/libxsmm_dnn_convolve_dryrun_upd_custom_custom_opt.tpl.c
+++ b/src/template/libxsmm_dnn_convolve_dryrun_upd_custom_custom_opt.tpl.c
@@ -257,7 +257,7 @@ for (ltid = 0; ltid < handle->desc.threads; ltid++)
                
                       /* use different weights format if we can skip init and copy */
                       if (mark_weight_init == 1 && mark_weight_copy == 1) {
-                        compute_indices[local_entries+1] = ( ( (ofm1-ofmb) * handle->block_upd_ifm ) + (ifm1-ifmb) ) * handle->desc.R * handle->desc.S * handle->ifmblock * handle->ofmblock + kj * handle->desc.S *  handle->ifmblock *  handle->ofmblock + ki * handle->ifmblock *  handle->ofmblock;
+                        compute_indices[local_entries+1] = ( ( (ofm1-ofmb) * LIBXSMM_MIN(handle->block_upd_ifm, handle->blocksifm) ) + (ifm1-ifmb) ) * handle->desc.R * handle->desc.S * handle->ifmblock * handle->ofmblock + kj * handle->desc.S *  handle->ifmblock *  handle->ofmblock + ki * handle->ifmblock *  handle->ofmblock;
                       } else {
                         compute_indices[local_entries+1] = ( ( (ofm1 *  handle->blocksifm ) + ifm1 ) * handle->desc.R * handle->desc.S *  handle->ifmblock *  handle->ofmblock + kj * handle->desc.S *  handle->ifmblock *  handle->ofmblock + ki * handle->ifmblock *  handle->ofmblock ) * handle->desc.threads;
                       }
@@ -342,7 +342,7 @@ for (ltid = 0; ltid < handle->desc.threads; ltid++)
 
                         if (mark_weight_init == 1) {
                           if ( (ki == 0) && (kj == 0) && (oi__ == 0) && (oj_ == ojb) && (ojb == 0) ) {
-                            encoded_code_segments[encoded_stream_index].aux_index = ( ( (ofm1-ofmb) * handle->block_upd_ifm ) + (ifm1-ifmb) ) * handle->desc.R * handle->desc.S * handle->ifmblock * handle->ofmblock;
+                            encoded_code_segments[encoded_stream_index].aux_index = ( ( (ofm1-ofmb) * LIBXSMM_MIN(handle->block_upd_ifm, handle->blocksifm) ) + (ifm1-ifmb) ) * handle->desc.R * handle->desc.S * handle->ifmblock * handle->ofmblock;
                             encoded_stream_index++;
                           }
                         }

--- a/src/template/libxsmm_dnn_convolve_st_upd_custom_custom_stream_opt.tpl.c
+++ b/src/template/libxsmm_dnn_convolve_st_upd_custom_custom_stream_opt.tpl.c
@@ -60,9 +60,9 @@ const int copy_thr_end = ((ltid + 1) * copychunksize < copywork) ? ((ltid + 1) *
 element_output_type *const out = ((element_output_type*)handle->grad_output->data) + (handle->desc.pad_h_out * handle->ofwp + handle->desc.pad_w_out) * handle->ofmblock;
 LIBXSMM_VLA_DECL(5, element_output_type, output, out, handle->blocksofm, handle->ofhp, handle->ofwp, handle->ofmblock);
 element_filter_type* weight_ptr = (element_filter_type*)handle->grad_filter->data;
-element_filter_type* per_thread_weight_ptr = ((element_filter_type*)handle->scratch4) + (ltid*handle->block_upd_ofm*handle->block_upd_ifm*handle->desc.R*handle->desc.S*handle->ifmblock*handle->ofmblock);
+element_filter_type* per_thread_weight_ptr = ((element_filter_type*)handle->scratch4) + (ltid*LIBXSMM_MIN(handle->block_upd_ofm,handle->blocksofm)*LIBXSMM_MIN(handle->block_upd_ifm,handle->blocksifm)*handle->desc.R*handle->desc.S*handle->ifmblock*handle->ofmblock);
 LIBXSMM_VLA_DECL(2, element_filter_type, per_thread_weight, per_thread_weight_ptr, handle->ofmblock);
-element_filter_type* reduction_weight_ptr = ((element_filter_type*)handle->scratch4) + (handle->desc.threads*handle->block_upd_ofm*handle->block_upd_ifm*handle->desc.R*handle->desc.S*handle->ifmblock*handle->ofmblock);
+element_filter_type* reduction_weight_ptr = ((element_filter_type*)handle->scratch4) + (handle->desc.threads*LIBXSMM_MIN(handle->block_upd_ofm,handle->blocksofm)*LIBXSMM_MIN(handle->block_upd_ifm,handle->blocksifm)*handle->desc.R*handle->desc.S*handle->ifmblock*handle->ofmblock);
 LIBXSMM_VLA_DECL(3, element_filter_type, reduction_weight, reduction_weight_ptr, handle->desc.threads, handle->ofmblock);
 
 /* Pointer related variables for input */

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-master-1.8.1-1027
+upd-weight-fix-1.8.1-1028


### PR DESCRIPTION
Per-thread weight storage should be based on min(block_upd_ofm, blocksofm).