### PR TITLE
Add __AVX512F__ guarded intrinsics for reduction

### DIFF
--- a/src/template/libxsmm_dnn_convolve_st_upd_custom_custom_stream_opt.tpl.c
+++ b/src/template/libxsmm_dnn_convolve_st_upd_custom_custom_stream_opt.tpl.c
@@ -284,33 +284,47 @@ if (n_segments) {
 if (handle->upd_use_external_reduce == 0) {
   libxsmm_barrier_wait(handle->barrier, ltid);
   for ( j = reduce_thr_begin; j < reduce_thr_end; j++ ) {
+#define __AVX512F__
+#ifdef __AVX512F__
+    __m512 weight_sum = _mm512_setzero_ps();
+    for ( i = 0; i < handle->desc.threads; i++ ) {
+      weight_sum = _mm512_add_ps(weight_sum, _mm512_load_ps(&LIBXSMM_VLA_ACCESS(3, reduction_weight, j, i, 0, handle->desc.threads, 16)));
+    }
+    if ( ((handle->options & LIBXSMM_DNN_CONV_OPTION_OVERWRITE) > 0) ) {
+      _mm512_stream_ps(&weight_ptr[j*16], weight_sum);
+    } else {
+      _mm512_store_ps(&weight_ptr[j*16], _mm512_add_ps(weight_sum, _mm512_load_ps(&weight_ptr[j*16])));
+    }
+#else
     element_filter_type weight_sum[16] LIBXSMM_ATTRIBUTE(aligned(64));
     LIBXSMM_PRAGMA_VALIGNED
-      LIBXSMM_PRAGMA_SIMD
-      for ( k = 0; k < 16; k++ ) {
-        weight_sum[k] = (element_filter_type) 0;
-      }
+    LIBXSMM_PRAGMA_SIMD
+    for ( k = 0; k < 16; k++ ) {
+      weight_sum[k] = (element_filter_type) 0;
+    }
     for ( i = 0; i < handle->desc.threads; i++ ) {
       LIBXSMM_PRAGMA_VALIGNED
-        LIBXSMM_PRAGMA_SIMD
-        for ( k = 0; k < 16; k++ ) {
-          weight_sum[k] += LIBXSMM_VLA_ACCESS(3, reduction_weight, j, i, k, handle->desc.threads, 16);
-        }
+      LIBXSMM_PRAGMA_SIMD
+      for ( k = 0; k < 16; k++ ) {
+        weight_sum[k] += LIBXSMM_VLA_ACCESS(3, reduction_weight, j, i, k, handle->desc.threads, 16);
+      }
     }
     if ( ((handle->options & LIBXSMM_DNN_CONV_OPTION_OVERWRITE) > 0) ) {
       LIBXSMM_PRAGMA_NONTEMPORAL
-        LIBXSMM_PRAGMA_VALIGNED
-        LIBXSMM_PRAGMA_SIMD
-        for ( k = 0; k < 16; k++ ) {
-          weight_ptr[j*16 + k] = weight_sum[k];
-        }
+      LIBXSMM_PRAGMA_VALIGNED
+      LIBXSMM_PRAGMA_SIMD
+      for ( k = 0; k < 16; k++ ) {
+        weight_ptr[j*16 + k] = weight_sum[k];
+      }
     } else {
       LIBXSMM_PRAGMA_VALIGNED
-        LIBXSMM_PRAGMA_SIMD
-        for ( k = 0; k < 16; k++ ) {
-          weight_ptr[j*16 + k] += weight_sum[k];
-        }
+      LIBXSMM_PRAGMA_SIMD
+      for ( k = 0; k < 16; k++ ) {
+        weight_ptr[j*16 + k] += weight_sum[k];
+      }
     }
+#endif
+#undef __AVX512F__
   }
 }
 libxsmm_barrier_wait(handle->barrier, ltid);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-master-1.8.1-1050
+upd-reduction-intrinsics-1.8.1-1051


### PR DESCRIPTION
As a temporary hack, __AVX512F__ is always defined/undefined around this block.